### PR TITLE
Feature: Determinant Progress Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,30 @@ AsyncButton {
 ```
 On macOS, you'll likely want to use the `.small` variant to match the standard system button.
 
+### Asynchronous Determinant Progress
+
+```swift
+AsyncProgressButton { progress in
+    progress.send(0.3)
+    try? await Task.sleep(nanoseconds: 3_000_000_000)
+    progress.send(0.7)
+    try? await Task.sleep(nanoseconds: 3_000_000_000)
+} label: {
+    Text("Process")
+}
+```
+
+`AsyncProgressButton` receives a parameter `CurrentValueSubject<Double>` that you can send values `0.0...1.0`. 
+
+You can control the color of the progress indicator using `.asyncButtonProgressColor`.
+
+```swift
+AsyncProgressButton { progress in
+    ...
+}
+.asyncButtonProgressColor(.white)
+```
+
 ## Contribute
 
 You are encouraged to contribute to this repository, by opening issues, or pull requests for bug fixes, improvement requests, or support. Suggestions for contributing:

--- a/README.md
+++ b/README.md
@@ -170,16 +170,16 @@ All sort of styles are built-in:
         <td><img src="/Preview/pulse.gif" width="250"></td>
     </tr>
     <tr>
-        <td>.throwableButtonStyle(.shake)</td>
-        <td>.throwableButtonStyle(.pulse)</td>
+        <td>.asyncButtonStyle(.overlay)</td>
+        <td>.asyncButtonStyle(.pulse)</td>
     </tr>
     <tr>
         <td><img src="/Preview/leading.gif" width="250"></td>
         <td><img src="/Preview/trailing.gif" width="250"></td>
     </tr>
     <tr>
-        <td>.throwableButtonStyle(.leading)</td>
-        <td>.throwableButtonStyle(.trailing)</td>
+        <td>.asyncButtonStyle(.leading)</td>
+        <td>.asyncButtonStyle(.trailing)</td>
     </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,15 @@ You can also build your own customization by implementing `AsyncButtonStyle` pro
 
 Just like `ThrowableButtonStyle`, `AsyncButtonStyle` allow you to implement either `makeLabel`, `makeButton` or both to alterate the button look and behavior while loading is in progress.
 
+You can control the size of the `ProgressView` inside `AsyncButton` using the `asyncButtonProgressViewSize` modifier.
+```swift
+AsyncButton {
+  ...
+}
+.asyncButtonProgressViewSize(.small)
+```
+On macOS, you'll likely want to use the `.small` variant to match the standard system button.
+
 ## Contribute
 
 You are encouraged to contribute to this repository, by opening issues, or pull requests for bug fixes, improvement requests, or support. Suggestions for contributing:

--- a/Sources/ButtonKit/AsyncStyle/AsyncStyle+Leading.swift
+++ b/Sources/ButtonKit/AsyncStyle/AsyncStyle+Leading.swift
@@ -47,7 +47,26 @@ extension AsyncButtonStyle where Self == LeadingAsyncButtonStyle {
     }
 }
 
-#Preview {
+#Preview("Determinant") {
+    AsyncProgressButton { progress in
+        progress.send(0.2)
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+        progress.send(0.2)
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+        progress.send(0.2)
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+        progress.send(0.2)
+        try await Task.sleep(nanoseconds: 3_000_000_000)
+        progress.send(0.2)
+    } label: {
+        Text("Leading")
+    }
+    .buttonStyle(.borderedProminent)
+    .asyncButtonStyle(.leading)
+}
+
+
+#Preview("Indeterminant") {
     AsyncButton {
         try await Task.sleep(nanoseconds: 30_000_000_000)
     } label: {

--- a/Sources/ButtonKit/Button+Async.swift
+++ b/Sources/ButtonKit/Button+Async.swift
@@ -205,16 +205,17 @@ extension AsyncButton where S == Text {
 }
 
 #Preview("Progress") {
-    AsyncProgressButton { continuation in
-        continuation.send(0.3)
+    AsyncProgressButton { progress in
+        progress.send(0.3)
         try? await Task.sleep(nanoseconds: 3_000_000_000)
-        continuation.send(0.7)
+        progress.send(0.7)
         try? await Task.sleep(nanoseconds: 3_000_000_000)
-        continuation.send(completion: .finished)
+        progress.send(completion: .finished)
     } label: {
         Text("Process")
     }
     .buttonStyle(.borderedProminent)
+    .asyncButtonProgressColor(.white)
     .asyncButtonStyle(.leading)
     .asyncButtonProgressViewSize(.small)
     .buttonBorderShape(.roundedRectangle)

--- a/Sources/ButtonKit/Button+Async.swift
+++ b/Sources/ButtonKit/Button+Async.swift
@@ -114,7 +114,10 @@ extension AsyncButton where S == Text {
         Text("Process")
     }
     .buttonStyle(.borderedProminent)
+    .asyncButtonStyle(.leading)
+    .asyncButtonProgressViewSize(.small)
     .buttonBorderShape(.roundedRectangle)
+    .frame(width: 400, height: 300)
 }
 
 #Preview("Error") {

--- a/Sources/ButtonKit/Button+Async.swift
+++ b/Sources/ButtonKit/Button+Async.swift
@@ -25,7 +25,78 @@
 //  SOFTWARE.
 //
 
+@preconcurrency import Combine
 import SwiftUI
+
+public struct AsyncProgressButton<S: View>: View {
+    @Environment(\.asyncButtonStyle)
+    private var asyncButtonStyle
+    @Environment(\.allowsHitTestingWhenLoading)
+    private var allowsHitTestingWhenLoading
+    @Environment(\.disabledWhenLoading)
+    private var disabledWhenLoading
+    @Environment(\.throwableButtonStyle)
+    private var throwableButtonStyle
+
+    private let role: ButtonRole?
+    private let action: (CurrentValueSubject<Double, Never>) async throws -> Void
+    private let label: S
+    private let progressStream: CurrentValueSubject<Double, Never> = .init(0)
+
+    @State private var task: Task<Void, Never>?
+    @State private var errorCount = 0
+    @State private var progressTask: Task<Void, Never>?
+
+    public var body: some View {
+        let throwableLabelConfiguration = ThrowableButtonStyleLabelConfiguration(
+            label: AnyView(label),
+            errorCount: errorCount
+        )
+        let asyncLabelConfiguration = AsyncButtonStyleLabelConfiguration(
+            isLoading: task != nil,
+            label: AnyView(throwableButtonStyle.makeLabel(configuration: throwableLabelConfiguration)),
+            cancel: { task?.cancel() }
+        )
+        let label = asyncButtonStyle.makeLabel(configuration: asyncLabelConfiguration)
+        let button = Button(role: role) {
+            guard task == nil else {
+                return
+            }
+            task = Task {
+                do {
+                    try await action(progressStream)
+                } catch {
+                    errorCount += 1
+                }
+                task = nil
+            }
+            
+        } label: {
+            label
+        }
+        let throwableConfiguration = ThrowableButtonStyleButtonConfiguration(
+            button: AnyView(button),
+            errorCount: errorCount
+        )
+        let asyncConfiguration = AsyncButtonStyleButtonConfiguration(
+            isLoading: task != nil,
+            button: AnyView(throwableButtonStyle.makeButton(configuration: throwableConfiguration)),
+            cancel: { task?.cancel() }
+        )
+        return asyncButtonStyle
+            .makeButton(configuration: asyncConfiguration)
+            .allowsHitTesting(allowsHitTestingWhenLoading || task == nil)
+            .disabled(disabledWhenLoading && task != nil)
+            .preference(key: AsyncButtonTaskPreferenceKey.self, value: task)
+            .environment(\.asyncButtonProgressSubject, progressStream)
+    }
+
+    public init(role: ButtonRole? = nil, action: @escaping (CurrentValueSubject<Double, Never>) async throws -> Void, @ViewBuilder label: @escaping () -> S) {
+        self.role = role
+        self.action = action
+        self.label = label()
+    }
+}
 
 public struct AsyncButton<S: View>: View {
     @Environment(\.asyncButtonStyle)
@@ -131,4 +202,21 @@ extension AsyncButton where S == Text {
     .buttonBorderShape(.roundedRectangle)
     .asyncButtonStyle(.overlay)
     .throwableButtonStyle(.shake)
+}
+
+#Preview("Progress") {
+    AsyncProgressButton { continuation in
+        continuation.send(0.3)
+        try? await Task.sleep(nanoseconds: 3_000_000_000)
+        continuation.send(0.7)
+        try? await Task.sleep(nanoseconds: 3_000_000_000)
+        continuation.send(completion: .finished)
+    } label: {
+        Text("Process")
+    }
+    .buttonStyle(.borderedProminent)
+    .asyncButtonStyle(.leading)
+    .asyncButtonProgressViewSize(.small)
+    .buttonBorderShape(.roundedRectangle)
+    .frame(width: 400, height: 300)
 }

--- a/Sources/ButtonKit/Button+AsyncStyle.swift
+++ b/Sources/ButtonKit/Button+AsyncStyle.swift
@@ -31,6 +31,9 @@ import SwiftUI
 // MARK: Public protocol
 
 extension View {
+    public func asyncButtonProgressColor(_ color: AsyncButtonDeterminantProgressColor) -> some View {
+        environment(\.asyncButtonProgressColor, color)
+    }
     public func asyncButtonProgressViewSize(_ size: AsyncButtonProgressViewSize) -> some View {
         environment(\.asyncButtonProgressViewSize, size)
     }
@@ -75,6 +78,12 @@ public struct AsyncButtonStyleButtonConfiguration {
 
 // MARK: SwiftUI Environment
 
+public typealias AsyncButtonDeterminantProgressColor = Color
+
+extension AsyncButtonDeterminantProgressColor: EnvironmentKey {
+    public static let defaultValue: AsyncButtonDeterminantProgressColor = .accentColor
+}
+
 public typealias AsyncButtonProgressSubject = CurrentValueSubject<Double, Never>
 
 extension AsyncButtonProgressSubject: EnvironmentKey {
@@ -92,6 +101,15 @@ struct AsyncButtonStyleKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
+    var asyncButtonProgressColor: AsyncButtonDeterminantProgressColor {
+        get {
+            return self[AsyncButtonDeterminantProgressColor.self]
+        }
+        set {
+            self[AsyncButtonDeterminantProgressColor.self] = newValue
+        }
+    }
+    
     var asyncButtonProgressSubject: AsyncButtonProgressSubject? {
         get {
             return self[AsyncButtonProgressSubject.self]

--- a/Sources/ButtonKit/Button+AsyncStyle.swift
+++ b/Sources/ButtonKit/Button+AsyncStyle.swift
@@ -30,6 +30,9 @@ import SwiftUI
 // MARK: Public protocol
 
 extension View {
+    public func asyncButtonProgressViewSize(_ size: AsyncButtonProgressViewSize) -> some View {
+        environment(\.asyncButtonProgressViewSize, size)
+    }
     public func asyncButtonStyle<S: AsyncButtonStyle>(_ style: S) -> some View {
         environment(\.asyncButtonStyle, AnyAsyncButtonStyle(style))
     }
@@ -71,11 +74,26 @@ public struct AsyncButtonStyleButtonConfiguration {
 
 // MARK: SwiftUI Environment
 
+public typealias AsyncButtonProgressViewSize = ControlSize
+
+extension AsyncButtonProgressViewSize: EnvironmentKey {
+    public static let defaultValue: ControlSize = .regular
+}
+
 struct AsyncButtonStyleKey: EnvironmentKey {
     static let defaultValue: AnyAsyncButtonStyle = AnyAsyncButtonStyle(.overlay)
 }
 
 extension EnvironmentValues {
+    var asyncButtonProgressViewSize: AsyncButtonProgressViewSize {
+        get {
+            return self[AsyncButtonProgressViewSize.self]
+        }
+        set {
+            self[AsyncButtonProgressViewSize.self] = newValue
+        }
+    }
+    
     var asyncButtonStyle: AnyAsyncButtonStyle {
         get {
             return self[AsyncButtonStyleKey.self]

--- a/Sources/ButtonKit/Button+AsyncStyle.swift
+++ b/Sources/ButtonKit/Button+AsyncStyle.swift
@@ -25,6 +25,7 @@
 //  SOFTWARE.
 //
 
+import Combine
 import SwiftUI
 
 // MARK: Public protocol
@@ -74,10 +75,16 @@ public struct AsyncButtonStyleButtonConfiguration {
 
 // MARK: SwiftUI Environment
 
+public typealias AsyncButtonProgressSubject = CurrentValueSubject<Double, Never>
+
+extension AsyncButtonProgressSubject: EnvironmentKey {
+    public static let defaultValue: AsyncButtonProgressSubject? = nil
+}
+
 public typealias AsyncButtonProgressViewSize = ControlSize
 
 extension AsyncButtonProgressViewSize: EnvironmentKey {
-    public static let defaultValue: ControlSize = .regular
+    public static let defaultValue: AsyncButtonProgressViewSize = .regular
 }
 
 struct AsyncButtonStyleKey: EnvironmentKey {
@@ -85,6 +92,15 @@ struct AsyncButtonStyleKey: EnvironmentKey {
 }
 
 extension EnvironmentValues {
+    var asyncButtonProgressSubject: AsyncButtonProgressSubject? {
+        get {
+            return self[AsyncButtonProgressSubject.self]
+        }
+        set {
+            self[AsyncButtonProgressSubject.self] = newValue
+        }
+    }
+    
     var asyncButtonProgressViewSize: AsyncButtonProgressViewSize {
         get {
             return self[AsyncButtonProgressViewSize.self]

--- a/Sources/ButtonKit/Button+AsyncTask.swift
+++ b/Sources/ButtonKit/Button+AsyncTask.swift
@@ -25,6 +25,7 @@
 //  SOFTWARE.
 //
 
+import Combine
 import SwiftUI
 
 // MARK: Public protocol
@@ -58,6 +59,14 @@ extension View {
 }
 
 // Internal implementation
+
+struct AsyncButtonProgressStreamPreferenceKey: PreferenceKey {
+    static var defaultValue: CurrentValueSubject<Double, Never>? = .init(0)
+
+    static func reduce(value: inout CurrentValueSubject<Double, Never>?, nextValue: () -> CurrentValueSubject<Double, Never>?) {
+        value = nextValue()
+    }
+}
 
 struct AsyncButtonTaskPreferenceKey: PreferenceKey {
     static var defaultValue: Task<Void, Never>?

--- a/Sources/ButtonKit/Subview/HierarchicalProgressView.swift
+++ b/Sources/ButtonKit/Subview/HierarchicalProgressView.swift
@@ -28,13 +28,19 @@
 import SwiftUI
 
 public struct HierarchicalProgressView: View {
+    @Environment(\.asyncButtonProgressViewSize)
+    private var controlSize
+    
     public var body: some View {
         ProgressView()
+            .controlSize(controlSize)
             .opacity(0)
             .overlay {
                 Rectangle()
                     .fill(.primary)
-                    .mask { ProgressView() }
+                    .mask {
+                        ProgressView().controlSize(controlSize)
+                    }
             }
             .compositingGroup()
     }

--- a/Sources/ButtonKit/Subview/HierarchicalProgressView.swift
+++ b/Sources/ButtonKit/Subview/HierarchicalProgressView.swift
@@ -31,6 +31,8 @@ import SwiftUI
 public struct HierarchicalProgressView: View {
     @Environment(\.asyncButtonProgressViewSize)
     private var controlSize
+    @Environment(\.asyncButtonProgressColor)
+    private var progressColor
     @Environment(\.asyncButtonProgressSubject)
     private var progressSubject
     @State private var progress: Double = 0
@@ -39,9 +41,9 @@ public struct HierarchicalProgressView: View {
         switch controlSize {
         case .mini: 1
         case .small: 2
-        case .regular: 4
+        case .regular: 3
         case .large: 5
-        default: 2
+        default: 4
         }
     }
     
@@ -59,9 +61,9 @@ public struct HierarchicalProgressView: View {
         switch controlSize {
         case .mini: 8
         case .small: 13
-        case .regular: 26
+        case .regular: 20
         case .large: 25
-        default: 10
+        default: 20
         }
     }
     
@@ -70,13 +72,13 @@ public struct HierarchicalProgressView: View {
             ZStack {
                 Circle()
                     .stroke(
-                        Color.primary.opacity(0.5),
+                        progressColor.opacity(0.5),
                         lineWidth: lineWidth
                     )
                 Circle()
                     .trim(from: 0, to: progress)
                     .stroke(
-                        Color.primary,
+                        progressColor,
                         lineWidth: lineWidth
                     )
                     .rotationEffect(.degrees(-90))
@@ -87,6 +89,8 @@ public struct HierarchicalProgressView: View {
             .onReceive(progressSubject, perform: { p in
                 progress = p
             })
+//            .colorInvert()
+            .contrast(0.8)
         }
         else {
             ProgressView()


### PR DESCRIPTION
Hey there, thanks for sharing this great library! On macOS the default `ProgressView` size is way out of scale with the default Button.

`main`
<img width="681" alt="Screenshot 2024-02-20 at 5 46 19 PM" src="https://github.com/Dean151/ButtonKit/assets/583594/332374f5-7b67-497e-b2c1-96a4bfb84cc5">

after this PR
<img width="803" alt="Screenshot 2024-02-20 at 5 46 33 PM" src="https://github.com/Dean151/ButtonKit/assets/583594/b3d55654-15d3-4fdc-84ba-61fbc1f8383d">

There's also a group of typos in the README that I fixed here.

Beyond those fixes, I wanted a determinant progress view so I added that :) I tried to emulate your naming style but can't read your mind so don't be shy about find & replacing my naming, won't hurt my feelings.